### PR TITLE
[Change] No header title as default

### DIFF
--- a/footnotesfromword/plugin.js
+++ b/footnotesfromword/plugin.js
@@ -76,12 +76,14 @@ CKEDITOR.plugins.add( 'footnotesfromword', {
             if ((/<section.*class="footnotes"/).test(data)) {
                 data = data.replace(/(<section.*class="footnotes"[^]*)<\/ol>[^]*?<\/section>/, '$1' + footnotes + '</ol></section>');
             } else {
-                var header_title = editor.config.footnotesTitle ? editor.config.footnotesTitle : 'Footnotes';
+                var header_title = editor.config.footnotesTitle ? editor.config.footnotesTitle : null;
                 var header_els = ['<h2>', '</h2>'];//editor.config.editor.config.footnotesHeaderEls
                 if (editor.config.footnotesHeaderEls) {
                     header_els = editor.config.footnotesHeaderEls;
                 }
-                data += '<section class="footnotes"><header>' + header_els[0] + header_title + header_els[1] + '<ol>' + footnotes + '</ol></section>';
+                data += '<section class="footnotes">';
+                data += header_title ? header_els[0] + header_title + header_els[1] : '';
+                data += '<ol>' + footnotes + '</ol></section';
             }
             editor.setData(data);
             editor.fire('unlockSnapshot');


### PR DESCRIPTION
Hello,

This plugin just helped me for my needs in some project, thank you for your work. (:

I added the possibility for the user to not put any header title (which was "Footnotes" as default).

Now if you set `editor.config.footnotesTitle` to `null` (or if you simply don't touch it), the footnotes won't have any title. Of course, you still can configure one, such as `editor.config.footnotesTitle = "References"`.

Have a nice day!

A